### PR TITLE
Use __dirname instead of npm bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The CodePush deploy task includes the following options which can be used to cus
 
 3. Enter your collection URL (Ex: https://localhost:8080/tfs/DefaultCollection) and user name and password 
 
-4. Download the [latest release](http://go.microsoft.com/fwlink/?LinkID=691191) of the CodePush task locally and unzip it
+4. Download the [latest release](https://github.com/Microsoft/code-push-vsts-extension/releases) of the CodePush task locally and unzip it
 
 5. Type the following from the root of the repo from Windows:
 

--- a/code-push-vsts-task/CodePush.js
+++ b/code-push-vsts-task/CodePush.js
@@ -3,8 +3,7 @@ var tl = require("vso-task-lib");
 require("shelljs/global");
 
 // Global variables.
-var localNpmBinaries = path.join(__dirname, "node_modules/.bin")
-var codePushCommandPrefix = path.join(localNpmBinaries, "code-push");
+var codePushCommandPrefix = "node " + path.join(__dirname, "node_modules/code-push-cli/script/cli");
 
 // Export for unit testing.
 function log(message) {

--- a/code-push-vsts-task/CodePush.js
+++ b/code-push-vsts-task/CodePush.js
@@ -3,7 +3,7 @@ var tl = require("vso-task-lib");
 require("shelljs/global");
 
 // Global variables.
-var localNpmBinaries = exec("npm bin", { silent: true }).output.replace(/(\r\n|\n|\r)/gm, "");
+var localNpmBinaries = path.join(__dirname, "node_modules/.bin")
 var codePushCommandPrefix = path.join(localNpmBinaries, "code-push");
 
 // Export for unit testing.

--- a/code-push-vsts-task/CodePush.js
+++ b/code-push-vsts-task/CodePush.js
@@ -3,7 +3,7 @@ var tl = require("vso-task-lib");
 require("shelljs/global");
 
 // Global variables.
-var codePushCommandPrefix = "node " + path.join(__dirname, "node_modules/code-push-cli/script/cli");
+var codePushCommandPrefix = "node " + path.join(__dirname, "node_modules", "code-push-cli", "script", "cli");
 
 // Export for unit testing.
 function log(message) {


### PR DESCRIPTION
Fixes an issue with running the tasks in certain environments whereby the task looks for the "code-push" command in the "node_modules/.bin" folder located at the root of the agent directory instead of in the task folder.

Also fixed a link in the README, it was pointing to the Cordova VSTS extension's releases tab instead of the releases tab in this repo.

@Chuxel @lostintangent 