### PR TITLE
Set default value for deployment option

### DIFF
--- a/Tasks/codepush-release/task.json
+++ b/Tasks/codepush-release/task.json
@@ -74,10 +74,10 @@
         {
             "name": "deploymentName",
             "type": "pickList",
-            "label": "Deployment Name",
-            "defaultValue": "",
+            "label": "Deployment",
+            "defaultValue": "Staging",
             "required": false,
-            "helpMarkDown": "Name of the deployment under the app which you want to push the release to",
+            "helpMarkDown": "Name of the deployment you want to release the update to",
             "options": {
                 "Production": "Production",
                 "Staging": "Staging"


### PR DESCRIPTION
This primarily changes the default value of the `Deployment` field to "Staging" and updates the label and description to match what we did for the `Promote` task