### PR TITLE
Adding HockeyApp auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ The **CodePush Promote** task allows you to promote a previously released update
     
     4. **Service Endpoint (HockeyApp)** - Allows you to reference a globally configured HockeyApp service endpoint.
 
-2. **App Name** (String, Required) - The name of the app that has the deployments you are targetting for promotion.
+2. **App Name** *(String, Required)* - The name of the app that has the deployments you are targeting for promotion.
 
-3. **Source Deployment** (String) - Name of the deployment you want to promote the latest release from. Defaults to `Staging`.
+3. **Source Deployment** *(String)* - Name of the deployment you want to promote the latest release from. Defaults to `Staging`.
 
-4. **Destination Deployment** (String) - Name of the deployment you want to promote the release to. Defaults to `Production`.
+4. **Destination Deployment** *(String)* - Name of the deployment you want to promote the release to. Defaults to `Production`.
 
 ##Installation
 

--- a/Tasks/codepush-promote/codepush-promote.js
+++ b/Tasks/codepush-promote/codepush-promote.js
@@ -55,7 +55,7 @@ function executeCommandAndHandleResult(cmd, positionArgs, optionFlags) {
 }
 
 function ensureLoggedOut() {
-    exec(buildCommand("logout", /*positionArgs*/ null, { local: true }), { silent: true });
+    exec(buildCommand("logout"), { silent: true });
 }
 
 // The main function to be executed.
@@ -64,8 +64,8 @@ function performPromoteTask(accessKey, appName, sourceDeploymentName, targetDepl
     var authType = tl.getInput("authType", false);
     if (authType === "AccessKey") {
         accessKey = tl.getInput("accessKey", true);
-    } else if (authType === "ServiceEndpoint") {
-        var serviceAccount = tl.getEndpointAuthorization(tl.getInput("serviceEndpoint", true));
+    } else if (authType === "ServiceEndpointCodePush" || authType === "ServiceEndpointHockeyApp") {
+        var serviceAccount = tl.getEndpointAuthorization(tl.getInput(authType, true));
         accessKey = serviceAccount.parameters.password;
     }
 

--- a/Tasks/codepush-promote/codepush-promote.ps1
+++ b/Tasks/codepush-promote/codepush-promote.ps1
@@ -1,7 +1,8 @@
 param (
     [string]$authType,
     [string]$accessKey,
-    [string]$serviceEndpoint,
+    [string]$serviceEndpointCodePush,
+    [string]$serviceEndpointHockeyApp,
     [string]$appName,
     [string]$sourceDeploymentName,
     [string]$targetDeploymentName
@@ -9,7 +10,8 @@ param (
   
 $env:INPUT_authType = $authType
 $env:INPUT_accessKey = $accessKey
-$env:INPUT_serviceEndpoint = $serviceEndpoint
+$env:INPUT_serviceEndpointCodePush = $serviceEndpointCodePush
+$env:INPUT_serviceEndpointHockeyApp = $serviceEndpointHockeyApp
 $env:INPUT_appName = $appName
 $env:INPUT_sourceDeploymentName = $sourceDeploymentName
 $env:INPUT_targetDeploymentName = $targetDeploymentName

--- a/Tasks/codepush-promote/package.json
+++ b/Tasks/codepush-promote/package.json
@@ -4,7 +4,8 @@
   "description": "A VSTS build/release task for promoting CodePush releases from one deployment to another",
   "main": "codepush-promote.js",
   "scripts": {
-    "deploy": "tfx build tasks upload ./ --overwrite"
+    "deploy": "tfx build tasks upload ./ --overwrite",
+    "test": "mocha test.js"
   },
   "author": "Microsoft Corporation",
   "license": "ISC",
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "sinon": "1.17.2",
-    "assert": "1.3.0"
+    "assert": "1.3.0",
+    "mocha": "~2.4.5"
   }
 }

--- a/Tasks/codepush-promote/task.json
+++ b/Tasks/codepush-promote/task.json
@@ -22,30 +22,31 @@
             "name": "authType",
             "type": "pickList",
             "label": "Authentication Method",
-            "defaultValue": "ServiceEndpoint",
+            "defaultValue": "AccessKey",
             "helpMarkDown": "",
             "options": {
                 "AccessKey": "Access Key",
-                "ServiceEndpoint": "Service Endpoint"
+                "ServiceEndpointCodePush": "Service Endpoint (CodePush)",
+                "ServiceEndpointHockeyApp": "Service Endpoint (HockeyApp)"
             }
         },
         {
-            "name": "serviceEndpoint",
+            "name": "serviceEndpointCodePush",
             "type": "connectedService:codepush-auth-key",
-            "label": "Service Endpoint",
+            "label": "Service Endpoint (CodePush)",
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "CodePush service endpoint that is configured with your account credentials.",
-            "visibleRule": "authType = ServiceEndpoint"
+            "visibleRule": "authType = ServiceEndpointCodePush"
         },
         {
-            "name": "accessKey",
-            "type": "string",
-            "label": "Access Key",
+            "name": "serviceEndpointHockeyApp",
+            "type": "connectedService:hockeyapp-endpoint-type",
+            "label": "Service Endpoint (HockeyApp)",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Access key used to authenticate with the CodePush service",
-            "visibleRule": "authType = AccessKey"
+            "helpMarkDown": "HockeyApp service endpoint that is configured with your account credentials.",
+            "visibleRule": "authType = ServiceEndpointHockeyApp"
         },
         {
             "name": "appName",

--- a/Tasks/codepush-promote/test.js
+++ b/Tasks/codepush-promote/test.js
@@ -73,10 +73,10 @@ describe("CodePush Promote Task", function() {
     performPromoteTask(); 
     
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
       "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME,
-      "logout --local"
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);
@@ -89,10 +89,10 @@ describe("CodePush Promote Task", function() {
     performPromoteTask();
     
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
       "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME,
-      "logout --local"
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);
@@ -105,9 +105,9 @@ describe("CodePush Promote Task", function() {
     performPromoteTask(/*shouldFail*/ true);
     
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
-      "logout --local"
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);
@@ -120,9 +120,9 @@ describe("CodePush Promote Task", function() {
     performPromoteTask(/*shouldFail*/ true);
 
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
-      "logout --local"
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);

--- a/Tasks/codepush-release/codepush-release.js
+++ b/Tasks/codepush-release/codepush-release.js
@@ -74,7 +74,7 @@ function performDeployTask(accessKey, appName, packagePath, appStoreVersion, dep
   appStoreVersion = appStoreVersion || tl.getInput("appStoreVersion", true);
   deploymentName  = deploymentName || tl.getInput("deploymentName", false);
   description     = description || tl.getInput("description", false);
-  rollout         = rollout || tl.getInput("rollout", null);
+  rollout         = rollout || tl.getInput("rollout", false);
   isMandatory     = isMandatory || tl.getInput("isMandatory", false);
   isDisabled      = isDisabled || tl.getInput("isDisabled", false);
   

--- a/Tasks/codepush-release/codepush-release.js
+++ b/Tasks/codepush-release/codepush-release.js
@@ -55,17 +55,17 @@ function executeCommandAndHandleResult(cmd, positionArgs, optionFlags) {
 }
 
 function ensureLoggedOut() {
-  exec(buildCommand("logout", /*positionArgs*/ null, { local: true }), { silent: true });
+  exec(buildCommand("logout"), { silent: true });
 }
 
 // The main function to be executed.
-function performDeployTask(accessKey, appName, packagePath, appStoreVersion, deploymentName, description, isMandatory) {
+function performDeployTask(accessKey, appName, packagePath, appStoreVersion, deploymentName, description, rollout, isMandatory, isDisabled) {
   // If function arguments are provided (e.g. during test), use those, else, get user inputs provided by VSTS.
   var authType = tl.getInput("authType", false);
   if (authType === "AccessKey") {
       accessKey = tl.getInput("accessKey", true);
-  } else if (authType === "ServiceEndpoint") {
-      var serviceAccount = tl.getEndpointAuthorization(tl.getInput("serviceEndpoint", true));
+  } else if (authType === "ServiceEndpointCodePush" || authType === "ServiceEndpointHockeyApp") {
+      var serviceAccount = tl.getEndpointAuthorization(tl.getInput(authType, true));
       accessKey = serviceAccount.parameters.password;
   }
 
@@ -74,7 +74,9 @@ function performDeployTask(accessKey, appName, packagePath, appStoreVersion, dep
   appStoreVersion = appStoreVersion || tl.getInput("appStoreVersion", true);
   deploymentName  = deploymentName || tl.getInput("deploymentName", false);
   description     = description || tl.getInput("description", false);
+  rollout         = rollout || tl.getInput("rollout", null);
   isMandatory     = isMandatory || tl.getInput("isMandatory", false);
+  isDisabled      = isDisabled || tl.getInput("isDisabled", false);
   
   if (!accessKey) {
       console.error("Access key required");
@@ -94,7 +96,9 @@ function performDeployTask(accessKey, appName, packagePath, appStoreVersion, dep
     { 
       deploymentName: deploymentName,
       description: description,
-      mandatory: isMandatory
+      rollout: rollout,
+      mandatory: isMandatory,
+      disabled: isDisabled
     }
   );
   

--- a/Tasks/codepush-release/codepush-release.ps1
+++ b/Tasks/codepush-release/codepush-release.ps1
@@ -1,23 +1,27 @@
 param (
     [string]$authType,
     [string]$accessKey,
-    [string]$serviceEndpoint,
+    [string]$serviceEndpointCodePush,
+    [string]$serviceEndpointHockeyApp,
     [string]$appName,
     [string]$packagePath,
     [string]$appStoreVersion,
     [string]$deploymentName,
     [string]$description,
-    [string]$isMandatory
+    [string]$isMandatory,
+    [string]$isDisabled
 ) 
   
 $env:INPUT_authType = $authType
 $env:INPUT_accessKey = $accessKey
-$env:INPUT_serviceEndpoint = $serviceEndpoint
+$env:INPUT_serviceEndpointCodePush = $serviceEndpointCodePush
+$env:INPUT_serviceEndpointHockeyApp = $serviceEndpointHockeyApp
 $env:INPUT_appName = $appName
 $env:INPUT_packagePath = $packagePath
 $env:INPUT_appStoreVersion = $appStoreVersion
 $env:INPUT_deploymentName = $deploymentName
 $env:INPUT_description = $description
 $env:INPUT_isMandatory = $isMandatory
+$env:INPUT_isDisabled = $isDisabled
 
 node codepush-release.js

--- a/Tasks/codepush-release/codepush-release.ps1
+++ b/Tasks/codepush-release/codepush-release.ps1
@@ -8,6 +8,7 @@ param (
     [string]$appStoreVersion,
     [string]$deploymentName,
     [string]$description,
+    [string]$rollout,
     [string]$isMandatory,
     [string]$isDisabled
 ) 
@@ -21,6 +22,7 @@ $env:INPUT_packagePath = $packagePath
 $env:INPUT_appStoreVersion = $appStoreVersion
 $env:INPUT_deploymentName = $deploymentName
 $env:INPUT_description = $description
+$env:INPUT_rolloutput = $rollout
 $env:INPUT_isMandatory = $isMandatory
 $env:INPUT_isDisabled = $isDisabled
 

--- a/Tasks/codepush-release/package.json
+++ b/Tasks/codepush-release/package.json
@@ -9,7 +9,7 @@
   "author": "Microsoft Corporation",
   "license": "ISC",
   "dependencies": {
-    "code-push-cli": "1.1.2-beta",
+    "code-push-cli": "1.8.2-beta",
     "vsts-task-lib": "0.5.7"
   },
   "devDependencies": {

--- a/Tasks/codepush-release/package.json
+++ b/Tasks/codepush-release/package.json
@@ -4,7 +4,8 @@
   "description": "A VSTS build/release task for releasing app updates to the CodePush service",
   "main": "codepush-release.js",
   "scripts": {
-    "deploy": "tfx build tasks upload ./ --overwrite"
+    "deploy": "tfx build tasks upload ./ --overwrite",
+    "test": "mocha test.js"
   },
   "author": "Microsoft Corporation",
   "license": "ISC",
@@ -14,6 +15,7 @@
   },
   "devDependencies": {
     "sinon": "1.17.2",
-    "assert": "1.3.0"
+    "assert": "1.3.0",
+    "mocha": "~2.4.5"
   }
 }

--- a/Tasks/codepush-release/task.json
+++ b/Tasks/codepush-release/task.json
@@ -22,21 +22,31 @@
             "name": "authType",
             "type": "pickList",
             "label": "Authentication Method",
-            "defaultValue": "ServiceEndpoint",
+            "defaultValue": "AccessKey",
             "helpMarkDown": "",
             "options": {
                 "AccessKey": "Access Key",
-                "ServiceEndpoint": "Service Endpoint"
+                "ServiceEndpointCodePush": "Service Endpoint (CodePush)",
+                "ServiceEndpointHockeyApp": "Service Endpoint (HockeyApp)"
             }
         },
         {
-            "name": "serviceEndpoint",
+            "name": "serviceEndpointCodePush",
             "type": "connectedService:codepush-auth-key",
-            "label": "Service Endpoint",
+            "label": "Service Endpoint (CodePush)",
             "defaultValue": "",
             "required": true,
             "helpMarkDown": "CodePush service endpoint that is configured with your account credentials.",
-            "visibleRule": "authType = ServiceEndpoint"
+            "visibleRule": "authType = ServiceEndpointCodePush"
+        },
+        {
+            "name": "serviceEndpointHockeyApp",
+            "type": "connectedService:hockeyapp-endpoint-type",
+            "label": "Service Endpoint (HockeyApp)",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "HockeyApp service endpoint that is configured with your account credentials.",
+            "visibleRule": "authType = ServiceEndpointHockeyApp"
         },
         {
             "name": "accessKey",
@@ -95,12 +105,28 @@
             "helpMarkDown": "Description of the update being released.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description."
         },
         {
+            "name": "rollout",
+            "type": "string",
+            "label": "Rollout",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a \"%\" suffix)."
+        },
+        {
             "name": "isMandatory",
             "type": "boolean",
             "label": "Mandatory",
             "defaultValue": false,
             "required": false,
             "helpMarkDown": "Specifies whether the release should be considered mandatory"
+        },
+        {
+            "name": "isDisabled",
+            "type": "boolean",
+            "label": "Disabled",
+            "defaultValue": false,
+            "required": false,
+            "helpMarkDown": "Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users."
         }
     ],
     "execution": {

--- a/Tasks/codepush-release/test.js
+++ b/Tasks/codepush-release/test.js
@@ -9,7 +9,9 @@ const PACKAGE_PATH      = "TestApp/www";
 const APP_STORE_VERSION = "1.0.0";
 const DEPLOYMENT_NAME   = "TestDeployment";
 const DESCRIPTION       = "This is a Test App";
+const ROLLOUT           = "25";
 const IS_MANDATORY      = true;
+const IS_DISABLED       = true;
 
 describe("CodePush Deploy Task", function() {
   var spies = [];
@@ -56,7 +58,7 @@ describe("CodePush Deploy Task", function() {
     spies.push(tl.setResult);
     
     try {
-      CodePush.performDeployTask(ACCESS_KEY, APP_NAME, PACKAGE_PATH, APP_STORE_VERSION, DEPLOYMENT_NAME, DESCRIPTION, IS_MANDATORY);
+      CodePush.performDeployTask(ACCESS_KEY, APP_NAME, PACKAGE_PATH, APP_STORE_VERSION, DEPLOYMENT_NAME, DESCRIPTION, ROLLOUT, IS_MANDATORY. IS_DISABLED);
     } catch (e) {
       assert(shouldFail, "Threw an unexpected error");
     }
@@ -76,10 +78,10 @@ describe("CodePush Deploy Task", function() {
     performDeployTask(); 
     
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
-      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName " + DEPLOYMENT_NAME + " --description \"" + DESCRIPTION + "\" --mandatory",
-      "logout --local"
+      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName " + DEPLOYMENT_NAME + " --description \"" + DESCRIPTION + "\" --rollout " + ROLLOUT + " --mandatory --disabled",
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);
@@ -92,10 +94,10 @@ describe("CodePush Deploy Task", function() {
     performDeployTask();
     
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
-      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName " + DEPLOYMENT_NAME + " --description \"" + DESCRIPTION + "\" --mandatory",
-      "logout --local"
+      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName " + DEPLOYMENT_NAME + " --description \"" + DESCRIPTION + "\" --rollout " + ROLLOUT + " --mandatory --disabled",
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);
@@ -108,9 +110,9 @@ describe("CodePush Deploy Task", function() {
     performDeployTask(/*shouldFail*/ true);
     
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
-      "logout --local"
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);
@@ -123,10 +125,10 @@ describe("CodePush Deploy Task", function() {
     performDeployTask(/*shouldFail*/ true);
 
     var expectedCommands = [
-      "logout --local",
+      "logout",
       "login --accessKey " + ACCESS_KEY,
-      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName " + DEPLOYMENT_NAME + " --description \"" + DESCRIPTION + "\" --mandatory",
-      "logout --local"
+      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName " + DEPLOYMENT_NAME + " --description \"" + DESCRIPTION + "\" --rollout " + ROLLOUT + " --mandatory --disabled",
+      "logout"
     ];
     
     checkCommandsEqual(expectedCommands, execStub);

--- a/Tasks/codepush-release/test.js
+++ b/Tasks/codepush-release/test.js
@@ -1,7 +1,7 @@
 var sinon = require("sinon");
 var assert = require("assert");
 var tl = require("vsts-task-lib");
-var CodePush = require("./CodePush");
+var CodePush = require("./codepush-release");
 
 const ACCESS_KEY        = "key123";
 const APP_NAME          = "TestApp";
@@ -58,7 +58,7 @@ describe("CodePush Deploy Task", function() {
     spies.push(tl.setResult);
     
     try {
-      CodePush.performDeployTask(ACCESS_KEY, APP_NAME, PACKAGE_PATH, APP_STORE_VERSION, DEPLOYMENT_NAME, DESCRIPTION, ROLLOUT, IS_MANDATORY. IS_DISABLED);
+      CodePush.performDeployTask(ACCESS_KEY, APP_NAME, PACKAGE_PATH, APP_STORE_VERSION, DEPLOYMENT_NAME, DESCRIPTION, ROLLOUT, IS_MANDATORY, IS_DISABLED);
     } catch (e) {
       assert(shouldFail, "Threw an unexpected error");
     }
@@ -127,7 +127,6 @@ describe("CodePush Deploy Task", function() {
     var expectedCommands = [
       "logout",
       "login --accessKey " + ACCESS_KEY,
-      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName " + DEPLOYMENT_NAME + " --description \"" + DESCRIPTION + "\" --rollout " + ROLLOUT + " --mandatory --disabled",
       "logout"
     ];
     

--- a/docs/extension-overview.md
+++ b/docs/extension-overview.md
@@ -2,7 +2,7 @@
 
 # Visual Studio Team Services Extension for CodePush
 
-This extension contains a set of deployment tasks which allow you to automate the release of app updates via CodePush from your CI environment. This can reduce the effort needed to keep your dev/alpha/beta/etc. deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest. No need to manually release or promote from the CodePush CLI!
+This extension contains a set of deployment tasks which allow you to automate the release of app updates via CodePush from your CI environment. This can reduce the effort needed to keep your dev/alpha/beta/etc. deployments up-to-date, since you can simply push changes to the configured source control branches, and let your automated build take care of the rest. No need to manually release, promote or rollout from the CodePush CLI!
 
 These tasks can be used with either VSTS or TFS 2015 on-prem servers (see below) and are intended to work with any Cordova or React Native project. Additionally, the tasks can be paired nicely with the [Cordova Command task](https://marketplace.visualstudio.com/items/ms-vsclient.cordova-extension) and/or the [React Native Bundle task](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.react-native-extension), which allow you to easily "prepare" the platform-specific assets that can be subsequently released to CodePush.
 
@@ -12,35 +12,41 @@ These tasks can be used with either VSTS or TFS 2015 on-prem servers (see below)
 
 1. Using the [CodePush CLI](http://microsoft.github.io/code-push/docs/cli.html), generate a new access key whose description indicates it will be used for VSTS CI builds (e.g. `code-push access-key create "VSTS CI"`)
 
+    *NOTE: If you provisioned your CodePush account from HockeyApp, you can use the API key that is displayed in the HockeyApp portal, and don't need to generate an additional key via the CodePush CLI.*
+    
 2. Install the CodePush extension from the [VSTS Marketplace](https://marketplace.visualstudio.com/items/ms-vsclient.code-push)
 
 3. Go to your Visual Studio Team Services or TFS project, click on the **Build** tab, and create a new build definition (the "+" icon) that is hooked up to your project's appropriate source repo
 
-4. Click **Add build step...** and select the neccessary tasks to generate your release assets (e.g. **Gulp**, **Cordova Build**)
+4. Click **Add build step...** and select the neccessary tasks to generate your release assets (e.g. **Gulp**, **Cordova Build**, **React Native Prepare**)
 
 5. Click **Add build step...** and select **CodePush Release** from the **Deploy** category
 
-6. Configure the deploy step with the access key created in step #1, specifying your app name, deployment name and app store version, and pointing to the output of the task(s) you added in step #4 (e.g. the directory containing your compiled/processed JS/HTML/CSS) 
+6. Configure the deploy step with the access key created in step #1, specifying your app name, deployment name and target binary version, and pointing to the output of the task(s) you added in step #4 (e.g. the directory containing your compiled/processed JS/HTML/CSS) 
 
 7. Click the **Queue Build** button or push a change to your repo in order to run the newly defined build pipeline
 
 8. Run your CodePush-ified app to see the change that was automatically deployed!
 
-## Configuring Your CodePush Credentials
+## Globally Configuring Your Credentials
 
-In addition to specifying your access key directly within a build task instance (as illustrated in step #4 above), you can also configure your CodePush credentials globally and refer to them within each build or release definition as needed. To do this, perform the following steps:
+In addition to specifying your access key directly within a build task instance (as illustrated in step #4 of the getting started section), you can also configure your CodePush credentials globally and refer to them within each build or release definition as needed. This can simplify the use of CodePush across a team, and increase security, since every build and release definition doesn't need to manually configure the account credentials. To do this, simply perform the following steps:
 
-1. Generate your access key as described above
+1. Generate or retrieve your access key as described above
+
+    *NOTE: If you need to retrieve a previously generated access key, you can run the `code-push access-key ls` command and look for the key with the description you specified when initially creating it.*
 
 2. Go into your Visual Studio Team Services or TFS project and click on the gear icon in the upper right corner
 
 3. Click on the **Services** tab
 
-4. Click on **New Service Endpoint** and select **CodePush**
+4. Click on **New Service Endpoint** and select **CodePush** or **HockeyApp**
 
-5. Give the new endpoint a name and enter the access key you generated in step#1
+5. Give the new endpoint a name (e.g. "MyApp-CodePush") and enter the access key you generated in step #1
 
 6. Select this endpoint via the name you chose in #5 whenever you add either the **CodePush Release** or **CodePush Promote** tasks to a build or release definition
+
+7. Release app updates!
 
 ## Task Option Reference
 
@@ -50,31 +56,47 @@ In addition to the custom service endpoint, this extension also contributes the 
 
 The **CodePush Release** task allows you to release an update to the CodePush server, and includes the following options:
 
-1. **Access Key** (String) or **Service Endpoint** - The access key to use to authenticate with the CodePush service. This value can be generated using the [CodePush CLI](https://github.com/Microsoft/code-push/tree/master/cli#authentication) and provided either directly to the task (via the `Access Key` authentication method), or configured within a service endpoint that you reference from the task (via the `Service Endpoint` authentication method).
+1. **Authentication Method** - Specifies how you would like to authenticate with the CodePush server. The available options are:
 
-2. **App Name** (String, Required) - The name of the app you want to release the update for.
+    1. **Access Key** - Allows you to directly specify an access key to the task. This value can either have been generated by the CodePush CLI, or provided to you by the HockeyApp portal after you auto-provisioned your CodePush account and app.
+    
+    2. **Service Endpoint (CodePush)** - Allows you to reference a globally configured CodePush service endpoint.
+    
+    4. **Service Endpoint (HockeyApp)** - Allows you to reference a globally configured HockeyApp service endpoint.
 
-3. **Update Contents Path** (File path, Required) - Path to the file or directory that contains the content(s) you want to release. For Cordova this should be the platform-specific `www` folder (e.g `platforms/ios/www`) and for React Native this should point to either your generated JS bundle file (e.g. `ios/main.jsbundle`) or a directory containing your JS bundle and assets, depending on if you're using the React Native assets system. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#update-contents-parameter) for more details.
+2. **App Name** *(String, Required)* - The name of the app you want to release the update for.
 
-4. **Target Binary Version** (String, Required) - The binary version that this release is targeting. The value must be [semver](http://semver.org/) compliant. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#target-binary-version-parameter) for more details.
+3. **Update Contents Path** *(File path, Required)* - Path to the file or directory that contains the content(s) you want to release. For Cordova this should be the platform-specific `www` folder (e.g `platforms/ios/www`) and for React Native this should point to either your generated JS bundle file (e.g. `ios/main.jsbundle`) or a directory containing your JS bundle and assets, depending on if you're using the React Native assets system. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#update-contents-parameter) for more details.
 
-5. **Deployment** (String) - Name of the deployment you want to release the update to. Defaults to `Staging`.
+4. **Target Binary Version** *(String, Required)* - The binary version that this release is targeting. The value must be [semver](http://semver.org/) compliant. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#target-binary-version-parameter) for more details.
 
-6. **Description** (String) - Description of the update being released. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+5. **Deployment** *(String)* - Name of the deployment you want to release the update to. Defaults to `Staging`.
 
-7. **Mandatory** (Boolean) - Specifies whether the release should be considered mandatory or not. Defaults to `false`.
+6. **Description** *(String)* - Description of the update being released. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+
+7. **Rollout** *(String)* - Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a "%" suffix). Defaults to `null`, which is equivalent to `100`, and therefore, makes the release available to everyone.
+
+8. **Mandatory** *(Boolean)* - Specifies whether the release should be considered mandatory or not. Defaults to `false`.
+
+9. **Disabled** *(Boolean)* - Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Defaults to `false`.
 
 ### CodePush Promote
 
 The **CodePush Promote** task allows you to promote a previously released update from one deployment to another, and includes the following options:
 
-1. **Access Key** (String) or **Service Endpoint** - The access key to use to authenticate with the CodePush service. This value can be generated using the [CodePush CLI](https://github.com/Microsoft/code-push/tree/master/cli#authentication) and provided either directly to the task (via the `Access Key` authentication method), or configured within a service endpoint that you reference from the task (via the `Service Endpoint` authentication method).
+1. **Authentication Method** - Specifies how you would like to authenticate with the CodePush server. The available options are:
 
-2. **App Name** (String, Required) - The name of the app that has the deployments you are targetting for promotion.
+    1. **Access Key** - Allows you to directly specify an access key to the task. This value can either have been generated by the CodePush CLI, or provided to you by the HockeyApp portal after you auto-provisioned your CodePush account and app.
+    
+    2. **Service Endpoint (CodePush)** - Allows you to reference a globally configured CodePush service endpoint.
+    
+    4. **Service Endpoint (HockeyApp)** - Allows you to reference a globally configured HockeyApp service endpoint.
 
-3. **Source Deployment** (String) - Name of the deployment you want to promote the latest release from. Defaults to `Staging`.
+2. **App Name** *(String, Required)* - The name of the app that has the deployments you are targeting for promotion.
 
-4. **Destination Deployment** (String) - Name of the deployment you want to promote the release to. Defaults to `Production`.
+3. **Source Deployment** *(String)* - Name of the deployment you want to promote the latest release from. Defaults to `Staging`.
+
+4. **Destination Deployment** *(String)* - Name of the deployment you want to promote the release to. Defaults to `Production`.
 
 ##Installation
 
@@ -114,6 +136,7 @@ The **CodePush Promote** task allows you to promote a previously released update
 6. Live long and prosper!
 
 ## Contact Us
+
 * [Email us your questions](mailto:codepushfeed@microsoft.com)
 * [Ask for help on StackOverflow](https://stackoverflow.com/questions/tagged/codepush)
 * [Follow the CodePush blog](http://microsoft.github.io/code-push/blog/index.html)


### PR DESCRIPTION
This PR primarily updates the release and promote tasks to support using a HockeyApp service endpoint to authenticate with CodePush. It also adds the new rollout and disabled fields to the release task, updates the CLI dependency, removes the use of the now deprecated `--local` flag for the `code-push logout` command, and updates the readme and tests as appropriate.

As a next step, I need to do the following:

1. Update the promote task to expose the mandatory, disabled, description and rollout fields.
2. Add a new patch task

Things I'm not going to do, but would be useful soon:

1. Remove our dependency on the CLI and use the management SDK instead
2. Add support for release-react and release-cordova