### PR TITLE
Promote task enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ The **CodePush Promote** task allows you to promote a previously released update
 
 4. **Destination Deployment** *(String)* - Name of the deployment you want to promote the release to. Defaults to `Production`.
 
+#### Update Metadata
+
+By default, when a release is promoted from one deployment to another, the newly created release will "inherit" not just the update contents, but also the metadata (e.g. `description`). This ensures that the exact same thing that you tested in one enivronment, will be promoted to another. However, if you need to override one or mote properties in the newly created release within the target deployment (e.g. because you use `mandatory` differently between environments), you can use the following fields:s 
+
+1. **Description** *(String)* - Description of the update being released. Leaving this field blank will result in the update inheriting the description from the release being promoted. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+
+2. **Rollout** *(String)* - Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a "%" suffix). Note that the rollout property will not be inherited from the release being promoted. Defaults to `null`, which is equivalent to `100`, and therefore, makes the release available to everyone.
+
+3. **Mandatory** *(Boolean)* - Specifies whether the release should be considered mandatory. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+
+4. **Disabled** *(Boolean)* - Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+
 ##Installation
 
 ### Visual Studio Team Services / Visual Studio Online

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The **CodePush Promote** task allows you to promote a previously released update
 
 #### Update Metadata
 
-By default, when a release is promoted from one deployment to another, the newly created release will "inherit" not just the update contents, but also the metadata (e.g. `description`). This ensures that the exact same thing that you tested in one enivronment, will be promoted to another. However, if you need to override one or mote properties in the newly created release within the target deployment (e.g. because you use `mandatory` differently between environments), you can use the following fields:s 
+By default, when a release is promoted from one deployment to another, the newly created release will "inherit" not just the update contents, but also the metadata (e.g. `description`). This ensures that what is being promoted is the exact same thing that you tested in the source deployment. However, if you need to override one or more properties in the newly created release within the target deployment (e.g. because you use `mandatory` differently between environments), you can use the following fields:
 
 1. **Description** *(String)* - Description of the update being released. Leaving this field blank will result in the update inheriting the description from the release being promoted. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
 

--- a/Tasks/codepush-promote/codepush-promote.ps1
+++ b/Tasks/codepush-promote/codepush-promote.ps1
@@ -5,7 +5,11 @@ param (
     [string]$serviceEndpointHockeyApp,
     [string]$appName,
     [string]$sourceDeploymentName,
-    [string]$targetDeploymentName
+    [string]$targetDeploymentName,
+    [string]$description,
+    [string]$rollout,
+    [string]$isMandatory,
+    [string]$isDisabled
 ) 
   
 $env:INPUT_authType = $authType
@@ -15,5 +19,9 @@ $env:INPUT_serviceEndpointHockeyApp = $serviceEndpointHockeyApp
 $env:INPUT_appName = $appName
 $env:INPUT_sourceDeploymentName = $sourceDeploymentName
 $env:INPUT_targetDeploymentName = $targetDeploymentName
+$env:INPUT_description = $description
+$env:INPUT_rolloutput = $rollout
+$env:INPUT_isMandatory = $isMandatory
+$env:INPUT_isDisabled = $isDisabled
 
 node codepush-promote.js

--- a/Tasks/codepush-promote/task.json
+++ b/Tasks/codepush-promote/task.json
@@ -17,6 +17,13 @@
     },
     "minimumAgentVersion": "1.83.0",
     "instanceNameFormat": "Promote $(sourceDeploymentName) to $(targetDeploymentName) for $(appName)",
+    "groups": [
+        {
+            "name": "updateMetadata",
+            "displayName": "Update Metadata",
+            "isExpanded": false
+        }
+    ],
     "inputs": [
         {
             "name": "authType",
@@ -84,6 +91,52 @@
             },
             "properties": {
                 "EditableOptions": "True"
+            }
+        },
+        {
+            "name": "description",
+            "type": "string",
+            "label": "Description",
+            "defaultValue": "",
+            "required": false,
+            "groupName": "updateMetadata",
+            "helpMarkDown": "Description of the update being released. Leaving this field blank will result in the update inheriting the description from the release being promoted.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description."
+        },
+        {
+            "name": "rollout",
+            "type": "string",
+            "label": "Rollout",
+            "defaultValue": "",
+            "required": false,
+            "groupName": "updateMetadata",
+            "helpMarkDown": "Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a \"%\" suffix). Note that the rollout property will not be inherited from the release being promoted."
+        },
+        {
+            "name": "isMandatory",
+            "type": "pickList",
+            "label": "Mandatory",
+            "defaultValue": "Inherit",
+            "required": true,
+            "groupName": "updateMetadata",
+            "helpMarkDown": "Specifies whether the release should be considered mandatory. Selecting \"Inherit\" will use the value from the release being promoted.",
+            "options": {
+                "Inherit": "Inherit",
+                "false": "No",
+                "true": "Yes"
+            }
+        },
+        {
+            "name": "isDisabled",
+            "type": "pickList",
+            "label": "Disabled",
+            "defaultValue": "Inherit",
+            "required": true,
+            "groupName": "updateMetadata",
+            "helpMarkDown": "Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Selecting \"Inherit\" will use the value from the release being promoted.",
+            "options": {
+                "Inherit": "Inherit",
+                "false": "No",
+                "true": "Yes"
             }
         }
     ],

--- a/Tasks/codepush-promote/test.js
+++ b/Tasks/codepush-promote/test.js
@@ -7,6 +7,10 @@ const ACCESS_KEY               = "key123";
 const APP_NAME                 = "TestApp";
 const SOURCE_DEPLOYMENT_NAME   = "TestSourceDeployment";
 const TARGET_DEPLOYMENT_NAME   = "TestTargetDeployment";
+const DESCRIPTION              = "";
+const ROLLOUT                  = "25%";
+const IS_MANDATORY             = "false";
+const IS_DISABLED              = "Inherit";
 
 describe("CodePush Promote Task", function() {
   var spies = [];
@@ -37,6 +41,7 @@ describe("CodePush Promote Task", function() {
     return execStub;
   }
   
+  
   function checkCommandsEqual(expectedCommands, execStub) {
     assert.equal(execStub.callCount, expectedCommands.length, "Expected " + expectedCommands.length + " commands, but executed " + execStub.callCount);
     expectedCommands.forEach(function(expectedCommand, i) {
@@ -53,7 +58,7 @@ describe("CodePush Promote Task", function() {
     spies.push(tl.setResult);
     
     try {
-      CodePush.performPromoteTask(ACCESS_KEY, APP_NAME, SOURCE_DEPLOYMENT_NAME, TARGET_DEPLOYMENT_NAME);
+      CodePush.performPromoteTask(ACCESS_KEY, APP_NAME, SOURCE_DEPLOYMENT_NAME, TARGET_DEPLOYMENT_NAME, DESCRIPTION, ROLLOUT, IS_MANDATORY, IS_DISABLED);
     } catch (e) {
       assert(shouldFail, "Threw an unexpected error");
     }
@@ -75,7 +80,7 @@ describe("CodePush Promote Task", function() {
     var expectedCommands = [
       "logout",
       "login --accessKey " + ACCESS_KEY,
-      "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME,
+      "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME + " --mandatory false --rollout " + ROLLOUT,
       "logout"
     ];
     
@@ -91,7 +96,7 @@ describe("CodePush Promote Task", function() {
     var expectedCommands = [
       "logout",
       "login --accessKey " + ACCESS_KEY,
-      "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME,
+      "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME + " --mandatory false --rollout " + ROLLOUT,
       "logout"
     ];
     

--- a/docs/extension-overview.md
+++ b/docs/extension-overview.md
@@ -98,6 +98,18 @@ The **CodePush Promote** task allows you to promote a previously released update
 
 4. **Destination Deployment** *(String)* - Name of the deployment you want to promote the release to. Defaults to `Production`.
 
+#### Update Metadata
+
+By default, when a release is promoted from one deployment to another, the newly created release will "inherit" not just the update contents, but also the metadata (e.g. `description`). This ensures that the exact same thing that you tested in one enivronment, will be promoted to another. However, if you need to override one or mote properties in the newly created release within the target deployment (e.g. because you use `mandatory` differently between environments), you can use the following fields:s 
+
+1. **Description** *(String)* - Description of the update being released. Leaving this field blank will result in the update inheriting the description from the release being promoted. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+
+2. **Rollout** *(String)* - Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a "%" suffix). Note that the rollout property will not be inherited from the release being promoted. Defaults to `null`, which is equivalent to `100`, and therefore, makes the release available to everyone.
+
+3. **Mandatory** *(Boolean)* - Specifies whether the release should be considered mandatory. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+
+4. **Disabled** *(Boolean)* - Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+
 ##Installation
 
 ### Visual Studio Team Services / Visual Studio Online


### PR DESCRIPTION
This PR enhances the existing promote task with a new "Update Metadata" group that allows users to override the metadata for the release being promoted.