### PR TITLE
Misc. updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,25 +72,25 @@ The **CodePush - Release** task allows you to release an update to the CodePush 
     
     4. **Service Endpoint (HockeyApp)** - Allows you to reference a globally configured HockeyApp service endpoint.
 
-2. **App Name** *(String, Required)* - The name of the app you want to release the update for.
+2. **App Name** *(String, Required)* - Name of the app you want to release the update for.
 
-3. **Update Contents Path** *(File path, Required)* - Path to the file or directory that contains the content(s) you want to release. For Cordova this should be the platform-specific `www` folder (e.g `platforms/ios/www`) and for React Native this should point to either your generated JS bundle file (e.g. `ios/main.jsbundle`) or a directory containing your JS bundle and assets, depending on if you're using the React Native assets system. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#update-contents-parameter) for more details.
+3. **Deployment** *(String)* - Name of the deployment you want to release the update to. Defaults to `Staging`.
 
-4. **Target Binary Version** *(String, Required)* - The binary version that this release is targeting. The value must be [semver](http://semver.org/) compliant. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#target-binary-version-parameter) for more details.
+4. **Update Contents Path** *(File path, Required)* - Path to the file or directory that contains the update you want to release. For Cordova this should be the platform-specific `www` folder (e.g `platforms/ios/www`) and for React Native this should point to either your generated JS bundle file (e.g. `ios/main.jsbundle`) or a directory containing your JS bundle and assets, depending on if you're using the React Native assets system. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#update-contents-parameter) for more details.
 
-5. **Deployment** *(String)* - Name of the deployment you want to release the update to. Defaults to `Staging`.
+5. **Target Binary Version** *(String, Required)* - Semver expression that specifies the binary app version(s) this release is targetting (e.g. 1.1.0, ~1.2.3). View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#target-binary-version-parameter) for more details.
 
-6. **Description** *(String)* - Description of the update being released. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+#### Update Metadata
 
-#### Advanced
+In addition to the basic properties, the follow options provide more advanced control over the release and how it will be distributed to your end users:
 
-In addition to the basic release properties, the follow options provide more advanced control over the update and how it will be distributed to your end users:
+1. **Rollout** *(String)* - Percentage of users this release should be immediately available to. Defaults to `100%`.
 
-1. **Rollout** *(String)* - Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a "%" suffix). Defaults to `null`, which is equivalent to `100`, and therefore, makes the release available to everyone.
+6. **Description** *(String)* - Description of the changes made to the app in this release. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
 
-2. **Mandatory** *(Boolean)* - Specifies whether the release should be considered mandatory or not. Defaults to `false`.
+2. **Mandatory** *(Boolean)* - Specifies whether this release should be considered mandatory. Defaults to `false`.
 
-3. **Disabled** *(Boolean)* - Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Defaults to `false`.
+3. **Disabled** *(Boolean)* - Specifies whether this release should be immediately downloadable. Defaults to `false`.
 
 ### CodePush - Promote
 
@@ -104,23 +104,23 @@ The **CodePush - Promote** task allows you to promote a previously released upda
     
     4. **Service Endpoint (HockeyApp)** - Allows you to reference a globally configured HockeyApp service endpoint.
 
-2. **App Name** *(String, Required)* - The name of the app that has the deployments you are targeting for promotion.
+2. **App Name** *(String, Required)* - Name of the app that has the deployments you are targeting for promotion.
 
 3. **Source Deployment** *(String)* - Name of the deployment you want to promote the latest release from. Defaults to `Staging`.
 
 4. **Destination Deployment** *(String)* - Name of the deployment you want to promote the release to. Defaults to `Production`.
 
-#### Advanced
+#### Update Metadata
 
 By default, when a release is promoted from one deployment to another, the newly created release will "inherit" not just the update contents, but also the metadata (e.g. `description`). This ensures that what is being promoted is the exact same thing that you tested in the source deployment. However, if you need to override one or more properties in the newly created release within the target deployment (e.g. because you use `mandatory` differently between environments), you can use the following fields:
 
-1. **Rollout** *(String)* - Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a "%" suffix). Note that the rollout property will not be inherited from the release being promoted. Defaults to `null`, which is equivalent to `100`, and therefore, makes the release available to everyone.
+1. **Rollout** *(String)* - Percentage of users this release should be immediately available to. Defaults to `100%`
 
-2. **Description** *(String)* - Description of the update being released. Leaving this field blank will result in the update inheriting the description from the release being promoted. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+2. **Description** *(String)* - Description of the changes made to the app in this release. Selecting `Inherit` will use the description from the release being promoted. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release. Defaults to `Inherit`.
 
-3. **Mandatory** *(Boolean)* - Specifies whether the release should be considered mandatory. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+3. **Mandatory** *(Boolean)* - Specifies whether this release should be considered mandatory. Selecting `Inherit` will use the mandatory attribute from the release being promoted. Defaults to `Inherit`.
 
-4. **Disabled** *(Boolean)* - Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+4. **Disabled** *(Boolean)* - Specifies whether this release should be immediately downloadable. Selecting `Inherit` will use the disabled attribute from the release being promoted. Defaults to `Inherit`.
 
 ##Installation
 

--- a/Tasks/codepush-promote/codepush-promote.js
+++ b/Tasks/codepush-promote/codepush-promote.js
@@ -15,7 +15,7 @@ function buildCommand(cmd, positionArgs, optionFlags) {
     var command = codePushCommandPrefix + " " + cmd;
 
     positionArgs && positionArgs.forEach(function (positionArg) {
-        command = command + " " + positionArg;
+        command = command + " \"" + positionArg + "\"";
     });
 
     for (var flag in optionFlags) {

--- a/Tasks/codepush-promote/codepush-promote.ps1
+++ b/Tasks/codepush-promote/codepush-promote.ps1
@@ -6,8 +6,8 @@ param (
     [string]$appName,
     [string]$sourceDeploymentName,
     [string]$targetDeploymentName,
-    [string]$description,
     [string]$rollout,
+    [string]$description,
     [string]$isMandatory,
     [string]$isDisabled
 ) 
@@ -19,8 +19,8 @@ $env:INPUT_serviceEndpointHockeyApp = $serviceEndpointHockeyApp
 $env:INPUT_appName = $appName
 $env:INPUT_sourceDeploymentName = $sourceDeploymentName
 $env:INPUT_targetDeploymentName = $targetDeploymentName
-$env:INPUT_description = $description
 $env:INPUT_rolloutput = $rollout
+$env:INPUT_description = $description
 $env:INPUT_isMandatory = $isMandatory
 $env:INPUT_isDisabled = $isDisabled
 

--- a/Tasks/codepush-promote/task.json
+++ b/Tasks/codepush-promote/task.json
@@ -38,6 +38,15 @@
             }
         },
         {
+            "name": "accessKey",
+            "type": "string",
+            "label": "Access Key",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Access key used to authenticate with the CodePush service.",
+            "visibleRule": "authType = AccessKey"
+        },
+        {
             "name": "serviceEndpointCodePush",
             "type": "connectedService:codepush-auth-key",
             "label": "Service Endpoint",
@@ -54,15 +63,6 @@
             "required": true,
             "helpMarkDown": "HockeyApp service endpoint that is configured with your account credentials.",
             "visibleRule": "authType = ServiceEndpointHockeyApp"
-        },
-        {
-            "name": "accessKey",
-            "type": "string",
-            "label": "Access Key",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Access key used to authenticate with the CodePush service.",
-            "visibleRule": "authType = AccessKey"
         },
         {
             "name": "appName",

--- a/Tasks/codepush-promote/task.json
+++ b/Tasks/codepush-promote/task.json
@@ -106,10 +106,10 @@
             "name": "rollout",
             "type": "string",
             "label": "Rollout",
-            "defaultValue": "",
+            "defaultValue": "100%",
             "required": false,
             "groupName": "advanced",
-            "helpMarkDown": "Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a \"%\" suffix). Note that the rollout property will not be inherited from the release being promoted."
+            "helpMarkDown": "Percentage of users this release should be immediately available to. Note that the rollout property will not be inherited from the release being promoted."
         },
         {
             "name": "description",
@@ -118,7 +118,7 @@
             "defaultValue": "Inherit",
             "required": true,
             "groupName": "advanced",
-            "helpMarkDown": "Description of the update being released. Selecting \"Inherit\" will use the value from the release being promoted.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description.",
+            "helpMarkDown": "Description of the changes made to the app in this release. Selecting \"Inherit\" will use the description from the release being promoted.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description.",
             "options": {
                 "Inherit": "Inherit"
             },
@@ -133,7 +133,7 @@
             "defaultValue": "Inherit",
             "required": true,
             "groupName": "advanced",
-            "helpMarkDown": "Specifies whether the release should be considered mandatory. Selecting \"Inherit\" will use the value from the release being promoted.",
+            "helpMarkDown": "Whether this release should be considered mandatory. Selecting \"Inherit\" will use the mandatory attribute from the release being promoted.",
             "options": {
                 "Inherit": "Inherit",
                 "false": "No",
@@ -147,7 +147,7 @@
             "defaultValue": "Inherit",
             "required": true,
             "groupName": "advanced",
-            "helpMarkDown": "Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Selecting \"Inherit\" will use the value from the release being promoted.",
+            "helpMarkDown": "Whether this release should be immediately downloadable. Selecting \"Inherit\" will use the disabled attribute from the release being promoted.",
             "options": {
                 "Inherit": "Inherit",
                 "false": "No",

--- a/Tasks/codepush-promote/task.json
+++ b/Tasks/codepush-promote/task.json
@@ -2,7 +2,7 @@
     "id": "4e901d0e-189b-4403-a030-1d06ff8a3b28",
     "name": "CodePushPromote",
     "friendlyName": "CodePush - Promote",
-    "description": "Promote a CodePush release from one deployment to another",
+    "description": "Promote the latest CodePush release from one app deployment to another",
     "author": "Microsoft Corporation",
     "category": "Deploy",
     "visibility": [
@@ -20,7 +20,7 @@
     "groups": [
         {
             "name": "advanced",
-            "displayName": "Advanced",
+            "displayName": "Update Metadata",
             "isExpanded": true
         }
     ],

--- a/Tasks/codepush-promote/test.js
+++ b/Tasks/codepush-promote/test.js
@@ -80,7 +80,7 @@ describe("CodePush Promote Task", function() {
     var expectedCommands = [
       "logout",
       "login --accessKey \"" + ACCESS_KEY + "\"",
-      "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME + " --mandatory \"false\" --rollout \"" + ROLLOUT + "\"",
+      "promote \"" + APP_NAME + "\" \"" + SOURCE_DEPLOYMENT_NAME + "\" \"" + TARGET_DEPLOYMENT_NAME + "\" --mandatory \"false\" --rollout \"" + ROLLOUT + "\"",
       "logout"
     ];
     
@@ -96,7 +96,7 @@ describe("CodePush Promote Task", function() {
     var expectedCommands = [
       "logout",
       "login --accessKey \"" + ACCESS_KEY + "\"",
-      "promote " + APP_NAME + " " + SOURCE_DEPLOYMENT_NAME + " " + TARGET_DEPLOYMENT_NAME + " --mandatory \"false\" --rollout \"" + ROLLOUT + "\"",
+      "promote \"" + APP_NAME + "\" \"" + SOURCE_DEPLOYMENT_NAME + "\" \"" + TARGET_DEPLOYMENT_NAME + "\" --mandatory \"false\" --rollout \"" + ROLLOUT + "\"",
       "logout"
     ];
     

--- a/Tasks/codepush-release/codepush-release.js
+++ b/Tasks/codepush-release/codepush-release.js
@@ -15,7 +15,7 @@ function buildCommand(cmd, positionArgs, optionFlags) {
   var command = codePushCommandPrefix + " " + cmd;
   
   positionArgs && positionArgs.forEach(function(positionArg) {
-    command = command + " " + positionArg;
+    command = command + " \"" + positionArg + "\"";
   });
   
   for (var flag in optionFlags) {

--- a/Tasks/codepush-release/codepush-release.ps1
+++ b/Tasks/codepush-release/codepush-release.ps1
@@ -4,11 +4,11 @@ param (
     [string]$serviceEndpointCodePush,
     [string]$serviceEndpointHockeyApp,
     [string]$appName,
+    [string]$deploymentName,
     [string]$packagePath,
     [string]$appStoreVersion,
-    [string]$deploymentName,
-    [string]$description,
     [string]$rollout,
+    [string]$description,
     [string]$isMandatory,
     [string]$isDisabled
 ) 
@@ -18,11 +18,11 @@ $env:INPUT_accessKey = $accessKey
 $env:INPUT_serviceEndpointCodePush = $serviceEndpointCodePush
 $env:INPUT_serviceEndpointHockeyApp = $serviceEndpointHockeyApp
 $env:INPUT_appName = $appName
+$env:INPUT_deploymentName = $deploymentName
 $env:INPUT_packagePath = $packagePath
 $env:INPUT_appStoreVersion = $appStoreVersion
-$env:INPUT_deploymentName = $deploymentName
-$env:INPUT_description = $description
 $env:INPUT_rolloutput = $rollout
+$env:INPUT_description = $description
 $env:INPUT_isMandatory = $isMandatory
 $env:INPUT_isDisabled = $isDisabled
 

--- a/Tasks/codepush-release/task.json
+++ b/Tasks/codepush-release/task.json
@@ -2,7 +2,7 @@
     "id": "b69d19a0-7f6d-11e5-a86a-c199aa7a6cf0",
     "name": "CodePushRelease",
     "friendlyName": "CodePush - Release",
-    "description": "Release an app update to the CodePush service",
+    "description": "Release an update to a CodePush app deployment",
     "author": "Microsoft Corporation",
     "category": "Deploy",
     "visibility": [
@@ -20,7 +20,7 @@
     "groups": [
         {
             "name": "advanced",
-            "displayName": "Advanced",
+            "displayName": "Update Metadata",
             "isExpanded": true
         }
     ],

--- a/Tasks/codepush-release/task.json
+++ b/Tasks/codepush-release/task.json
@@ -78,7 +78,7 @@
             "label": "Update Contents Path",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Path to the file or directory that contains the content you want to release."
+            "helpMarkDown": "Path to the file or directory that contains the update you want to release."
         },
         {
             "name": "appStoreVersion",
@@ -86,7 +86,7 @@
             "label": "Target Binary Version",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "The binary version that this update is targeting (must be semver compliant)."
+            "helpMarkDown": "Semver expression that specifies the binary app version(s) this release is targetting (e.g. 1.1.0, ~1.2.3)."
         },
         {
             "name": "deploymentName",
@@ -109,7 +109,7 @@
             "label": "Description",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Description of the update being released.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description."
+            "helpMarkDown": "Description of the changes made to the app in this release.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description."
         },
         {
             "name": "rollout",
@@ -118,7 +118,7 @@
             "defaultValue": "",
             "required": false,
             "groupName": "advanced",
-            "helpMarkDown": "Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a \"%\" suffix)."
+            "helpMarkDown": "Percentage of users this release should be immediately available to."
         },
         {
             "name": "isMandatory",
@@ -127,7 +127,7 @@
             "defaultValue": false,
             "required": false,
             "groupName": "advanced",
-            "helpMarkDown": "Specifies whether the release should be considered mandatory."
+            "helpMarkDown": "Whether this release should be considered mandatory."
         },
         {
             "name": "isDisabled",
@@ -136,7 +136,7 @@
             "defaultValue": false,
             "required": false,
             "groupName": "advanced",
-            "helpMarkDown": "Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users."
+            "helpMarkDown": "Whether this release should be immediately downloadable."
         }
     ],
     "execution": {

--- a/Tasks/codepush-release/task.json
+++ b/Tasks/codepush-release/task.json
@@ -73,6 +73,21 @@
             "helpMarkDown": "Name of the app you want to release an update for."
         },
         {
+            "name": "deploymentName",
+            "type": "pickList",
+            "label": "Deployment",
+            "defaultValue": "Staging",
+            "required": false,
+            "helpMarkDown": "Name of the deployment you want to release the update to.",
+            "options": {
+                "Production": "Production",
+                "Staging": "Staging"
+            },
+            "properties": {
+                "EditableOptions": "True"
+            }
+        },
+        {
             "name": "packagePath",
             "type": "filePath",
             "label": "Update Contents Path",
@@ -89,19 +104,13 @@
             "helpMarkDown": "Semver expression that specifies the binary app version(s) this release is targetting (e.g. 1.1.0, ~1.2.3)."
         },
         {
-            "name": "deploymentName",
-            "type": "pickList",
-            "label": "Deployment",
-            "defaultValue": "Staging",
+            "name": "rollout",
+            "type": "string",
+            "label": "Rollout",
+            "defaultValue": "100%",
             "required": false,
-            "helpMarkDown": "Name of the deployment you want to release the update to.",
-            "options": {
-                "Production": "Production",
-                "Staging": "Staging"
-            },
-            "properties": {
-                "EditableOptions": "True"
-            }
+            "groupName": "advanced",
+            "helpMarkDown": "Percentage of users this release should be immediately available to."
         },
         {
             "name": "description",
@@ -109,16 +118,8 @@
             "label": "Description",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Description of the changes made to the app in this release.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description."
-        },
-        {
-            "name": "rollout",
-            "type": "string",
-            "label": "Rollout",
-            "defaultValue": "",
-            "required": false,
             "groupName": "advanced",
-            "helpMarkDown": "Percentage of users this release should be immediately available to."
+            "helpMarkDown": "Description of the changes made to the app in this release.<br />Note: This can be set to **$(Release.ReleaseDescription)** if being run within a release definition, and you want to inherit the release's description."
         },
         {
             "name": "isMandatory",

--- a/Tasks/codepush-release/task.json
+++ b/Tasks/codepush-release/task.json
@@ -38,6 +38,15 @@
             }
         },
         {
+            "name": "accessKey",
+            "type": "string",
+            "label": "Access Key",
+            "defaultValue": "",
+            "required": true,
+            "helpMarkDown": "Access key used to authenticate with the CodePush service.",
+            "visibleRule": "authType = AccessKey"
+        },
+        {
             "name": "serviceEndpointCodePush",
             "type": "connectedService:codepush-auth-key",
             "label": "Service Endpoint",
@@ -56,21 +65,12 @@
             "visibleRule": "authType = ServiceEndpointHockeyApp"
         },
         {
-            "name": "accessKey",
-            "type": "string",
-            "label": "Access Key",
-            "defaultValue": "",
-            "required": true,
-            "helpMarkDown": "Access key used to authenticate with the CodePush service.",
-            "visibleRule": "authType = AccessKey"
-        },
-        {
             "name": "appName",
             "type": "string",
             "label": "App Name",
             "defaultValue": "",
             "required": true,
-            "helpMarkDown": "Name of the app you want to release an update for."
+            "helpMarkDown": "Name of the app you want to release the update for."
         },
         {
             "name": "deploymentName",

--- a/Tasks/codepush-release/test.js
+++ b/Tasks/codepush-release/test.js
@@ -80,7 +80,7 @@ describe("CodePush Deploy Task", function() {
     var expectedCommands = [
       "logout",
       "login --accessKey \"" + ACCESS_KEY + "\"",
-      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName \"" + DEPLOYMENT_NAME + "\" --description \"" + DESCRIPTION + "\" --rollout \"" + ROLLOUT + "\" --disabled",
+      "release \"" + APP_NAME + "\" \"" + PACKAGE_PATH + "\" \"" + APP_STORE_VERSION + "\" --deploymentName \"" + DEPLOYMENT_NAME + "\" --description \"" + DESCRIPTION + "\" --rollout \"" + ROLLOUT + "\" --disabled",
       "logout"
     ];
     
@@ -96,7 +96,7 @@ describe("CodePush Deploy Task", function() {
     var expectedCommands = [
       "logout",
       "login --accessKey \"" + ACCESS_KEY + "\"",
-      "release " + APP_NAME + " " + PACKAGE_PATH + " " + APP_STORE_VERSION + " --deploymentName \"" + DEPLOYMENT_NAME + "\" --description \"" + DESCRIPTION + "\" --rollout \"" + ROLLOUT + "\" --disabled",
+      "release \"" + APP_NAME + "\" \"" + PACKAGE_PATH + "\" \"" + APP_STORE_VERSION + "\" --deploymentName \"" + DEPLOYMENT_NAME + "\" --description \"" + DESCRIPTION + "\" --rollout \"" + ROLLOUT + "\" --disabled",
       "logout"
     ];
     

--- a/docs/extension-overview.md
+++ b/docs/extension-overview.md
@@ -64,25 +64,25 @@ The **CodePush - Release** task allows you to release an update to the CodePush 
     
     4. **Service Endpoint (HockeyApp)** - Allows you to reference a globally configured HockeyApp service endpoint.
 
-2. **App Name** *(String, Required)* - The name of the app you want to release the update for.
+2. **App Name** *(String, Required)* - Name of the app you want to release the update for.
 
-3. **Update Contents Path** *(File path, Required)* - Path to the file or directory that contains the content(s) you want to release. For Cordova this should be the platform-specific `www` folder (e.g `platforms/ios/www`) and for React Native this should point to either your generated JS bundle file (e.g. `ios/main.jsbundle`) or a directory containing your JS bundle and assets, depending on if you're using the React Native assets system. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#update-contents-parameter) for more details.
+3. **Deployment** *(String)* - Name of the deployment you want to release the update to. Defaults to `Staging`.
 
-4. **Target Binary Version** *(String, Required)* - The binary version that this release is targeting. The value must be [semver](http://semver.org/) compliant. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#target-binary-version-parameter) for more details.
+4. **Update Contents Path** *(File path, Required)* - Path to the file or directory that contains the update you want to release. For Cordova this should be the platform-specific `www` folder (e.g `platforms/ios/www`) and for React Native this should point to either your generated JS bundle file (e.g. `ios/main.jsbundle`) or a directory containing your JS bundle and assets, depending on if you're using the React Native assets system. View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#update-contents-parameter) for more details.
 
-5. **Deployment** *(String)* - Name of the deployment you want to release the update to. Defaults to `Staging`.
+5. **Target Binary Version** *(String, Required)* - Semver expression that specifies the binary app version(s) this release is targetting (e.g. 1.1.0, ~1.2.3). View the [CLI docs](http://microsoft.github.io/code-push/docs/cli.html#target-binary-version-parameter) for more details.
 
-6. **Description** *(String)* - Description of the update being released. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+#### Update Metadata
 
-#### Advanced
+In addition to the basic properties, the follow options provide more advanced control over the release and how it will be distributed to your end users:
 
-In addition to the basic release properties, the follow options provide more advanced control over the update and how it will be distributed to your end users:
+1. **Rollout** *(String)* - Percentage of users this release should be immediately available to. Defaults to `100%`.
 
-1. **Rollout** *(String)* - Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a "%" suffix). Defaults to `null`, which is equivalent to `100`, and therefore, makes the release available to everyone.
+6. **Description** *(String)* - Description of the changes made to the app in this release. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
 
-2. **Mandatory** *(Boolean)* - Specifies whether the release should be considered mandatory or not. Defaults to `false`.
+2. **Mandatory** *(Boolean)* - Specifies whether this release should be considered mandatory. Defaults to `false`.
 
-3. **Disabled** *(Boolean)* - Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Defaults to `false`.
+3. **Disabled** *(Boolean)* - Specifies whether this release should be immediately downloadable. Defaults to `false`.
 
 ### CodePush - Promote
 
@@ -96,23 +96,23 @@ The **CodePush - Promote** task allows you to promote a previously released upda
     
     4. **Service Endpoint (HockeyApp)** - Allows you to reference a globally configured HockeyApp service endpoint.
 
-2. **App Name** *(String, Required)* - The name of the app that has the deployments you are targeting for promotion.
+2. **App Name** *(String, Required)* - Name of the app that has the deployments you are targeting for promotion.
 
 3. **Source Deployment** *(String)* - Name of the deployment you want to promote the latest release from. Defaults to `Staging`.
 
 4. **Destination Deployment** *(String)* - Name of the deployment you want to promote the release to. Defaults to `Production`.
 
-#### Advanced
+#### Update Metadata
 
 By default, when a release is promoted from one deployment to another, the newly created release will "inherit" not just the update contents, but also the metadata (e.g. `description`). This ensures that what is being promoted is the exact same thing that you tested in the source deployment. However, if you need to override one or more properties in the newly created release within the target deployment (e.g. because you use `mandatory` differently between environments), you can use the following fields:
 
-1. **Rollout** *(String)* - Percentage of users you want this update to be available for, specified as a number between `1` and `100` (you can optionally specify a "%" suffix). Note that the rollout property will not be inherited from the release being promoted. Defaults to `null`, which is equivalent to `100`, and therefore, makes the release available to everyone.
+1. **Rollout** *(String)* - Percentage of users this release should be immediately available to. Defaults to `100%`
 
-2. **Description** *(String)* - Description of the update being released. Leaving this field blank will result in the update inheriting the description from the release being promoted. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release.
+2. **Description** *(String)* - Description of the changes made to the app in this release. Selecting `Inherit` will use the description from the release being promoted. When this task is used within a VSTS release definition, this field can be set to the `$(Release.ReleaseDescription)` variable in order to inherit the description that was given to the release. Defaults to `Inherit`.
 
-3. **Mandatory** *(Boolean)* - Specifies whether the release should be considered mandatory. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+3. **Mandatory** *(Boolean)* - Specifies whether this release should be considered mandatory. Selecting `Inherit` will use the mandatory attribute from the release being promoted. Defaults to `Inherit`.
 
-4. **Disabled** *(Boolean)* - Specifies whether the release should be disabled, and therefore, not immediately downloadable by end-users. Selecting `Inherit` will use the value from the release being promoted. Defaults to `Inherit`.
+4. **Disabled** *(Boolean)* - Specifies whether this release should be immediately downloadable. Selecting `Inherit` will use the disabled attribute from the release being promoted. Defaults to `Inherit`.
 
 ##Installation
 


### PR DESCRIPTION
This PR makes three primary changes:

1. Ensures the descriptions of each input field are consistent with the CLI
2. Makes the rollout property default to `100%`
3. Moves the description field to the advanced group in the release task